### PR TITLE
Feat/skip rerun virtual service

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -62,6 +62,7 @@
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
         "eslint": "^9.19.0",
+        "eslint-config-prettier": "^10.1.1",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-react": "^7.37.4",
         "eslint-plugin-react-hooks": "^5.1.0",
@@ -5819,6 +5820,18 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.1.tgz",
+      "integrity": "sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/preswald/browser/virtual_service.py
+++ b/preswald/browser/virtual_service.py
@@ -193,7 +193,6 @@ class VirtualPreswaldService:
 
         def handle_message_from_js(client_id, message_type, data):
             try:
-                from js import Object  # type: ignore
                 import json
 
                 # Convert JsProxy to real Python dict using JSON workaround
@@ -212,9 +211,9 @@ class VirtualPreswaldService:
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.debug(f"Handling JS message from {client_id}: {message}")
 
-                asyncio.create_task(self.handle_client_message(client_id, message))
+                asyncio.create_task(self.handle_client_message(client_id, message))   # noqa: RUF006
                 return True
-            except Exception as e:
+            except Exception:
                 import traceback
                 logger.error("Error in handle_message_from_js: %s", traceback.format_exc())
                 return False
@@ -323,7 +322,7 @@ class VirtualPreswaldService:
         }
 
         if not changed_states:
-            logger.debug(f"[STATE] No actual state changes detected. Skipping rerun.")
+            logger.debug("[STATE] No actual state changes detected. Skipping rerun.")
             return
 
         # Update only changed states

--- a/preswald/browser/virtual_service.py
+++ b/preswald/browser/virtual_service.py
@@ -191,15 +191,33 @@ class VirtualPreswaldService:
         # Create proxies for JavaScript to call Python
         from pyodide.ffi import create_proxy  # type: ignore
 
-        # Handler for incoming messages from JavaScript
         def handle_message_from_js(client_id, message_type, data):
-            """Handle message from JavaScript"""
-            logger.info(f"Received message from JS: {message_type}")
+            try:
+                from js import Object  # type: ignore
+                import json
 
-            # Create a task to handle the message asynchronously
-            message = {"type": message_type, "data": data}
-            asyncio.create_task(self.handle_client_message(client_id, message))  # noqa: RUF006
-            return True
+                # Convert JsProxy to real Python dict using JSON workaround
+                # Note: Although we're on Pyodide 0.27.2, the environment seems to lack `to_py`
+                # likely due to an incomplete or custom Pyodide build
+
+                json_str = window.JSON.stringify(data)
+                py_data = json.loads(json_str)
+
+                if isinstance(py_data, dict):
+                    message = dict(py_data)
+                    message["type"] = message_type
+                else:
+                    message = {"type": message_type, "data": py_data}
+
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(f"Handling JS message from {client_id}: {message}")
+
+                asyncio.create_task(self.handle_client_message(client_id, message))
+                return True
+            except Exception as e:
+                import traceback
+                logger.error("Error in handle_message_from_js: %s", traceback.format_exc())
+                return False
 
         # Export the function to JavaScript
         handle_message_proxy = create_proxy(handle_message_from_js)
@@ -296,17 +314,29 @@ class VirtualPreswaldService:
             await self._send_error(client_id, "Component update missing states")
             raise ValueError("Component update missing states")
 
-        # Update component states
-        self._update_component_states(states)
+        # Only rerun if any state actually changed
+        from preswald.engine.utils import clean_nan_values
+
+        changed_states = {
+            k: v for k, v in states.items()
+            if clean_nan_values(self.get_component_state(k)) != clean_nan_values(v)
+        }
+
+        if not changed_states:
+            logger.debug(f"[STATE] No actual state changes detected. Skipping rerun.")
+            return
+
+        # Update only changed states
+        self._update_component_states(changed_states)
         self._layout_manager.clear_layout()
 
         # Update states and trigger script rerun
         runner = self.script_runners.get(client_id)
         if runner:
-            await runner.rerun(states)
+            await runner.rerun(changed_states)
 
         # Broadcast updates to other clients
-        await self._broadcast_state_updates(states, exclude_client=client_id)
+        await self._broadcast_state_updates(changed_states, exclude_client=client_id)
 
     def _update_component_states(self, states: Dict[str, Any]):
         """Update component states"""

--- a/tests/pyodide_test.html
+++ b/tests/pyodide_test.html
@@ -37,32 +37,34 @@
         // await pyodide.runPythonAsync(`
         //   import micropip
         //   await micropip.install("preswald")
-          
+
         //   # Try importing your modules
         //   import preswald
         //   print("Successfully imported preswald")
-          
+
         //   # Test specific modules/functionality
         //   # import preswald.submodule
         //   # print(preswald.__version__)
         // `);
-        
+
         // Alternative 2: If not published, you can load from wheel
         // First, build your wheel: python -m build --wheel
         // Then serve it locally and load it:
         await pyodide.runPythonAsync(`
           import micropip
-          await micropip.install("http://localhost:8000/preswald-0.1.38-py3-none-any.whl")
+          await micropip.install("http://localhost:8000/dist/preswald-0.1.49-py3-none-any.whl");
           import preswald
           print("Successfully imported from wheel")
-        `);
-        
+          from preswald.engine.service import PreswaldService
+          PreswaldService.initialize()
+    `);
+
         appendOutput("All tests completed!");
       } catch (error) {
         appendOutput("ERROR: " + error);
       }
     }
-    
+
     main();
   </script>
 </body>


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to contribute to the project
title: 'feat(runtime): add RenderBuffer to VirtualPreswaldService to skip redundant reruns'
labels: ''
assignees: ''
---

**Related Issue**
Fixes # (no formal issue number, part of the broader [XL] Reactive Runtime effort). See [[Preswald][XL] Reactive Runtime](https://trello.com/c/IcMdxnLf/2572-preswaldxl-reactive-runtime)

**Description of Changes**
- This PR is stacked on top of [#604](https://github.com/StructuredLabs/preswald/pull/604), please review that PR first.
- Introduces a `RenderBuffer` class to `engine/utils.py` for tracking component render state.
- Integrates the `RenderBuffer` into `VirtualPreswaldService` to prevent unnecessary reruns when incoming state is identical to the previous state.
- Adds debug output to confirm when reruns are skipped or triggered.
- This change is part of a broader reactive runtime refactor and will be followed by a similar change to `ServerPreswaldService`.

**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**
- Manual testing in `pyodide_test.html` by repeatedly sending identical and changing state messages from the browser console.
- Observed correct behavior in the test page's `<textarea>` output:
  - First update triggered a rerun.
  - Subsequent identical updates did not.
  - A new value triggered another rerun as expected.

![image](https://github.com/user-attachments/assets/1c09d4ca-6818-4899-924d-27c65612caf3)

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [ ] Any dependent changes have been merged and published in downstream modules
